### PR TITLE
Add deployment workflow and example CloudFormation stack

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Build & Deploy
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          python -m pip install ./python/src
+          npm --prefix web ci
+          npm --prefix web run build
+
+      - name: Run tests
+        run: python -m pytest
+
+      - name: Package Lambda artifacts
+        run: |
+          mkdir -p artifacts
+          zip -r artifacts/lambda_layer.zip python/src/wrfcloud
+          zip -r artifacts/lambda_function.zip python/src/lambda_wrapper.py python/src/wrfcloud
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Upload artifacts to S3
+        run: |
+          aws s3 cp artifacts/lambda_layer.zip s3://${{ secrets.AWS_ARTIFACT_BUCKET }}/
+          aws s3 cp artifacts/lambda_function.zip s3://${{ secrets.AWS_ARTIFACT_BUCKET }}/
+
+      - name: Deploy CloudFormation stack
+        run: |
+          aws cloudformation deploy \
+            --template-file deploy_wrfcloud_stack.yaml \
+            --stack-name ${{ secrets.APP_STACK_NAME }} \
+            --capabilities CAPABILITY_NAMED_IAM \
+            --no-fail-on-empty-changeset

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # WRF Cloud
-[![codecov](https://codecov.io/github/ncar/wrfcloud/branch/develop/graph/badge.svg?token=1950DDI9D2)](https://app.codecov.io/gh/NCAR/wrfcloud)
+[![codecov](https://codecov.io/github/ncar/wrfcloud/branch/develop/graph/badge.svg?token=1950DDI9D2)](https://app.codecov.io/gh/
+NCAR/wrfcloud)
 
 The WRF Cloud framework is a cloud-based forecasting system designed to facilitate easy, cost-effective, state-of-the-art numerical weather prediction system forecasts for communities that lack large computational resources.
 
 ## Documetation & Information
-System overview, installation and usage information can be found in the [Users Guide](https://wrfcloud.readthedocs.io/en/stable/). 
+System overview, installation and usage information can be found in the [Users Guide](https://wrfcloud.readthedocs.io/en/stable/).
 
 Questions can be posted to the [GitHub Discussions](https://github.com/NCAR/wrfcloud/discussions) page.
 
 More information:
 [wrfcloud.com](https://wrfcloud.com) or email at info@wrfcloud.com
 
-
+## Deployment
+A sample GitHub Actions workflow (`.github/workflows/deploy.yml`) automates building, testing, packaging, and deploying the application to AWS. The workflow uploads Lambda artifacts to an S3 bucket and deploys a CloudFormation stack defined in `deploy_wrfcloud_stack.yaml`. Configure the required AWS credentials and bucket and stack names as repository secrets before running the workflow.

--- a/deploy_wrfcloud_stack.yaml
+++ b/deploy_wrfcloud_stack.yaml
@@ -21,8 +21,13 @@ Resources:
             Version: "2012-10-17"
             Statement:
               - Effect: Allow
-                Action: "*"
-                Resource: "*"
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                  - s3:ListBucket
+                Resource:
+                  - !GetAtt WrfCloudBucket.Arn
+                  - !Sub "${WrfCloudBucket.Arn}/*"
   WrfCloudFunction:
     Type: AWS::Lambda::Function
     Properties:

--- a/deploy_wrfcloud_stack.yaml
+++ b/deploy_wrfcloud_stack.yaml
@@ -1,0 +1,37 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Minimal WRFCloud infrastructure
+Resources:
+  WrfCloudBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "wrfcloud-${AWS::AccountId}-${AWS::Region}"
+  LambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: WrfCloudPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: "*"
+                Resource: "*"
+  WrfCloudFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Bucket: !Ref WrfCloudBucket
+        S3Key: lambda_function.zip
+      Handler: lambda_wrapper.lambda_handler
+      Role: !GetAtt LambdaRole.Arn
+      Runtime: python3.9
+Outputs:
+  BucketName:
+    Value: !Ref WrfCloudBucket


### PR DESCRIPTION
## Summary
- document GitHub Actions deployment in README
- add workflow to build, test, package and deploy to AWS
- include minimal CloudFormation stack template

## Testing
- `python -m pip install ./python/src` *(fails: `pkgutil` has no attribute `ImpImporter`)*
- `python -m pytest` *(fails: `ModuleNotFoundError: No module named 'wrfcloud'`)*

------
https://chatgpt.com/codex/tasks/task_e_688daaf067d88321818ceccbbbadf479