### PR TITLE
chore: update artifact action version

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -30,12 +30,12 @@ jobs:
           python -m pip install python-dateutil requests Pillow
       - name: Build docs
         run: ./.github/jobs/build_documentation.sh   
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: documentation
           path: artifact/documentation
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: documentation_warnings.log


### PR DESCRIPTION
## Summary
- update upload-artifact action to v4 in documentation workflow

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'wrfcloud')*

------
https://chatgpt.com/codex/tasks/task_e_688db30be6e48321848ee1d8f637c487