### PR TITLE
Add OpenCL reshaping utility and handle GRIB timestamps

### DIFF
--- a/python/src/wrfcloud/runtime/opencl_utils.py
+++ b/python/src/wrfcloud/runtime/opencl_utils.py
@@ -1,0 +1,43 @@
+"""Utility functions using OpenCL for GPU acceleration."""
+from typing import Sequence
+
+import numpy
+
+try:
+    import pyopencl as cl  # type: ignore
+    _CONTEXT = cl.create_some_context()
+    _QUEUE = cl.CommandQueue(_CONTEXT)
+    _OPENCL_AVAILABLE = True
+except Exception:  # pragma: no cover - OpenCL not always available
+    _OPENCL_AVAILABLE = False
+    _CONTEXT = None
+    _QUEUE = None
+
+
+def reshape_1d_to_2d(data: Sequence[float], x: int, y: int) -> numpy.ndarray:
+    """Reshape a 1D array into a 2D array using GPU if available."""
+    array = numpy.asarray(data, dtype=numpy.float32)
+    if array.size != x * y:
+        raise ValueError('Input data size does not match provided dimensions')
+
+    if not _OPENCL_AVAILABLE:
+        return array.reshape((y, x))
+
+    kernel_code = """
+    __kernel void reshape(__global const float *in,
+                          __global float *out,
+                          const unsigned int width) {
+        int gid = get_global_id(0);
+        int row = gid / width;
+        int col = gid % width;
+        out[row*width + col] = in[gid];
+    }
+    """
+    program = cl.Program(_CONTEXT, kernel_code).build()
+    mf = cl.mem_flags
+    in_buffer = cl.Buffer(_CONTEXT, mf.READ_ONLY | mf.COPY_HOST_PTR, hostbuf=array)
+    out_buffer = cl.Buffer(_CONTEXT, mf.WRITE_ONLY, array.nbytes)
+    program.reshape(_QUEUE, array.shape, None, in_buffer, out_buffer, numpy.uint32(x))
+    result = numpy.empty_like(array)
+    cl.enqueue_copy(_QUEUE, result, out_buffer)
+    return result.reshape((y, x))

--- a/python/src/wrfcloud/runtime/tools/geojson.py
+++ b/python/src/wrfcloud/runtime/tools/geojson.py
@@ -19,6 +19,7 @@ import numpy
 from numpy.ma.core import MaskedArray
 # pylint: disable=E0401
 import pygrib
+from wrfcloud.runtime.opencl_utils import reshape_1d_to_2d
 
 from wrfcloud.jobs.job import WrfLayer, Palette
 from wrfcloud.log import Logger
@@ -54,6 +55,7 @@ class GeoJson:
         self.contour_interval = contour_interval
         self.palette = palette
         self.time_step = 0
+        self.dt = 0
 
     def convert(self, out_file: Union[str, None]) -> Union[None, dict]:
         """
@@ -129,30 +131,33 @@ class GeoJson:
         Read the variable data, latitude, and longitude grids from a GRIB2 file
         :return: data, latitude, longitude
         """
-        # read grib2 file with pygrib & eccodes
         wrf = pygrib.open(self.wrf_file)  # pylint: disable=E1101
 
-        # determine if we are after a 2D or 3D field
-        grid = self._read_2d_from_grib(wrf) if self.z_level is None else self._read_3d_from_grib(wrf)
-
-        # get the latitude and longitude grids
-        grid_lat = MaskedArray(wrf.select(shortName='nlat')[0].values)
-        grid_lon = MaskedArray(wrf.select(shortName='elon')[0].values) - 360
+        if self.z_level is None:
+            grid, grid_lat, grid_lon = self._read_2d_from_grib(wrf)
+        else:
+            grid = self._read_3d_from_grib(wrf)
+            grid_lat = MaskedArray(wrf.select(shortName='nlat')[0].values)
+            grid_lon = MaskedArray(wrf.select(shortName='elon')[0].values) - 360
 
         return grid, grid_lat, grid_lon
 
-    def _read_2d_from_grib(self, wrf: any) -> MaskedArray:
+    def _read_2d_from_grib(self, wrf: any) -> (MaskedArray, MaskedArray, MaskedArray):
         """
         Read the 2D variable data from a GRIB2 file
         :param wrf: pygrib.open object to read the GRIB2 file
-        :return: data
+        :return: data, latitude, longitude
         """
-        # read grib2 file with pygrib & eccodes
+        grid_lat = MaskedArray(wrf.select(shortName='nlat')[0].values)
+        grid_lon = MaskedArray(wrf.select(shortName='elon')[0].values) - 360
         variable = wrf.select(shortName=self.variable)
-        # TODO: self.layer.dt = variable[0].validDate
-        grid = MaskedArray(variable[0].values)
+        self.dt = int(variable[0].validDate.timestamp())
+        values = variable[0].values
+        if values.ndim == 1:
+            values = reshape_1d_to_2d(values, grid_lat.shape[1], grid_lat.shape[0])
+        grid = MaskedArray(values)
 
-        return grid
+        return grid, grid_lat, grid_lon
 
     def _read_3d_from_grib(self, wrf: any) -> MaskedArray:
         """
@@ -165,21 +170,6 @@ class GeoJson:
         grid = MaskedArray(variable[0].values)
 
         return grid
-
-    @staticmethod
-    def _1d_to_2d(data: MaskedArray, x: int, y: int) -> MaskedArray:
-        """
-        Convert a 1D array to a 2D grid
-        :param data: Data array to convert
-        :param x: X dimension
-        :param y: Y dimension
-        :return: 2D grid
-        """
-        data2d = []
-        for i in range(0, x*y, x):
-            data2d.append(data[i:i+x])
-
-        return MaskedArray(data2d, ndmin=2)
 
     def _grid_to_lonlat(self, x: float, y: float) -> (float, float):
         """


### PR DESCRIPTION
## Summary
- use OpenCL when available to reshape 1D arrays into 2D grids
- record GRIB validDate timestamps and drop unused TODO code

## Testing
- `PYTHONPATH=python/src pytest` *(fails: ModuleNotFoundError: No module named 'bcrypt')*


------
https://chatgpt.com/codex/tasks/task_e_68942093c32c832198aa818ec68fc9ea